### PR TITLE
adds the ability to define a custom timestamp generator

### DIFF
--- a/lib/txn.js
+++ b/lib/txn.js
@@ -22,19 +22,20 @@ var util = require('util')
   ;
 
 require('defaultable').def(module,
-  { 'log'       : log4js.getLogger('txn')
-  , 'log_level' : process.env.txn_log_level || 'info'
-  , 'timestamps': false
-  , 'create'    : false
-  , 'max_tries' : 5
-  , 'after'     : null
-  , 'delay'     : 100
-  , 'timeout'   : 15 * 1000
-  , 'operation' : null
-  , 'req'       : null
-  , 'couch'     : null
-  , 'db'        : null
-  , 'id'        : null
+  { 'log'                : log4js.getLogger('txn')
+  , 'log_level'          : process.env.txn_log_level || 'info'
+  , 'timestamps'         : false
+  , 'timestamp_generator': function() { return new Date(); }
+  , 'create'             : false
+  , 'max_tries'          : 5
+  , 'after'              : null
+  , 'delay'              : 100
+  , 'timeout'            : 15 * 1000
+  , 'operation'          : null
+  , 'req'                : null
+  , 'couch'              : null
+  , 'db'                 : null
+  , 'id'                 : null
   }, function(module, exports, DEFAULT, require) {
 
 
@@ -105,15 +106,16 @@ function Transaction (opts) {
   var self = this;
   EventEmitter.call(self);
 
-  self.req       = opts.req       || DEFAULT.req;
-  self.couch     = opts.couch     || DEFAULT.couch;
-  self.db        = opts.db        || DEFAULT.db;
-  self.id        = opts.id        || DEFAULT.id;
-  self.doc       = opts.doc       || null;
-  self.operation = opts.operation || DEFAULT.operation;
-  self.timeout   = opts.timeout   || DEFAULT.timeout;
-  self.delay     = opts.delay     || DEFAULT.delay;
-  self.log       = opts.log       || DEFAULT.log;
+  self.req                 = opts.req                 || DEFAULT.req;
+  self.couch               = opts.couch               || DEFAULT.couch;
+  self.db                  = opts.db                  || DEFAULT.db;
+  self.id                  = opts.id                  || DEFAULT.id;
+  self.doc                 = opts.doc                 || null;
+  self.operation           = opts.operation           || DEFAULT.operation;
+  self.timeout             = opts.timeout             || DEFAULT.timeout;
+  self.delay               = opts.delay               || DEFAULT.delay;
+  self.log                 = opts.log                 || DEFAULT.log;
+  self.timestamp_generator = opts.timestamp_generator || DEFAULT.timestamp_generator;
 
   self.log.setLevel(DEFAULT.log_level);
 
@@ -286,7 +288,7 @@ Transaction.prototype.run = function() {
         doc._rev = original.rev;
 
       if(!! self.timestamps) {
-        doc.updated_at = JSON.stringify(new Date).replace(/"/g, '');
+        doc.updated_at = JSON.stringify(self.timestamp_generator()).replace(/"/g, '');
         if(is_create)
           doc.created_at = doc.updated_at;
       }


### PR DESCRIPTION
Hey there, I've added the ability for you to define a custom timestamp generator when using timestamps (created_at/updated_at).

This is really useful because I like storing dates as unix time (easier for indexing/sorting later). This is how its used:

``` js
txn = require('txn').defaults({timestamps: true, timestamp_generator: function() { return new Date().getTime() });
```

It works as usual, if nothing is specified. We could rename the property, if you have a better idea for what it should be called.
